### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Publish to Github Packages Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           MONGO: ${{ secrets.MONGO }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore